### PR TITLE
feat(go-license-tools): Add branch reference argument to point to specific branches to fetch license from

### DIFF
--- a/py/kubeflow/testing/go-license-tools/README.md
+++ b/py/kubeflow/testing/go-license-tools/README.md
@@ -83,6 +83,11 @@ $ python <license_tool>/setup.py install
     doesn't have a github understandable license file. Check its readme and
     update correct info into `license-info.csv`. (Usually, use its README file which mentions license.)
 
+    Optionally, provide a file with branch references if you would like to point to a specific branch of the repository. (e.g. `SeldonIO/seldon-core,v2`)
+    ```
+    $ python <license_tool>/get_github_license_info.py --github-api-token-file=<github_token_file> --branch-refs=<branch_refs_file>
+    ```
+
 2. Fill in missing license information. If you open `license_info.csv`, you can see some fields are marked as `Other`. We have to update them to the right license types. First we need to grep all these unknown license URLs:
     ```
     $ cat license_info.csv | grep Other | cut -d ',' -f 2

--- a/py/kubeflow/testing/go-license-tools/README.md
+++ b/py/kubeflow/testing/go-license-tools/README.md
@@ -83,7 +83,7 @@ $ python <license_tool>/setup.py install
     doesn't have a github understandable license file. Check its readme and
     update correct info into `license-info.csv`. (Usually, use its README file which mentions license.)
 
-    Optionally, provide a file with branch references if you would like to point to a specific branch of the repository. (e.g. `SeldonIO/seldon-core,v2`)
+    Optionally, provide a file with branch references if you would like to point to a specific branch of the repository. (e.g. `seldonio/seldon-core,v2`)
     ```
     $ python <license_tool>/get_github_license_info.py --github-api-token-file=<github_token_file> --branch-refs=<branch_refs_file>
     ```

--- a/py/kubeflow/testing/go-license-tools/get_github_license_info.py
+++ b/py/kubeflow/testing/go-license-tools/get_github_license_info.py
@@ -86,7 +86,6 @@ def main():
         with open(args.branch_refs, 'r') as branch_refs_file:
           for line in branch_refs_file:
             repo, branch = line.strip().split(',')
-            assert len(repo.split('/')) == 2, 'repo name should be org/repo, but is {}'.format(repo)
             branch_refs[repo] = branch
       except FileNotFoundError:
         raise Exception('branch_refs file {} not found'.format(args.branch_refs))

--- a/py/kubeflow/testing/go-license-tools/get_github_license_info.py
+++ b/py/kubeflow/testing/go-license-tools/get_github_license_info.py
@@ -52,7 +52,7 @@ parser.add_argument(
   dest='branch_refs',
   help=
   'Optional file with each line specifying the branch ref separated by a comma.'
-  +'Format: org/repo,branch_name. e.g. SeldonIO/seldon-core,v2.',
+  +'Format: org/repo,branch_name. e.g. seldonio/seldon-core,v2.',
 )
 args = parser.parse_args()
 

--- a/py/kubeflow/testing/go-license-tools/setup.py
+++ b/py/kubeflow/testing/go-license-tools/setup.py
@@ -15,7 +15,7 @@
 from setuptools import setup
 
 NAME = 'go-license-tools'
-VERSION = '0.0.1'
+VERSION = '0.0.2'
 
 REQUIRES = [
     'bs4',


### PR DESCRIPTION
**Description of your changes:**

Currently the `LICENSE` file is fetched from the default branch for a given GitHub repository.
We have a usecase where we might want to point to a specific branch (e.g `v2` branch of `SeldonIO/seldon-core`).

This PR adds a new argument to the `get_github_license_info` module in the `go-license-tools` with a custom mapping of `org/repo` to `branch_name`, denoted as a comma separated line e.g. `seldonio/seldon-core,v2`.

The branch name is used as a `ref` query parameter in the REST endpoint from the GitHub API to fetch licenses, equivalent to

`master` branch
```
$ curl https://api.github.com/repos/seldonio/seldon-core/license
{
  "name": "LICENSE",
  "path": "LICENSE",
  "sha": "a6df4c3013370efab4e4856c66005a10c7ebb319",
  "size": 4436,
  "url": "https://api.github.com/repos/SeldonIO/seldon-core/contents/LICENSE?ref=master",
  "html_url": "https://github.com/SeldonIO/seldon-core/blob/master/LICENSE",
  "git_url": "https://api.github.com/repos/SeldonIO/seldon-core/git/blobs/a6df4c3013370efab4e4856c66005a10c7ebb319",
  "download_url": "https://raw.githubusercontent.com/SeldonIO/seldon-core/master/LICENSE",
  "type": "file",
...
```

`v2` branch
```
$ curl https://api.github.com/repos/seldonio/seldon-core/license?ref=v2
{
  "name": "LICENSE",
  "path": "LICENSE",
  "sha": "61137502263e30fd4017add89159cd9ffbee8320",
  "size": 4436,
  "url": "https://api.github.com/repos/SeldonIO/seldon-core/contents/LICENSE?ref=v2",
  "html_url": "https://github.com/SeldonIO/seldon-core/blob/v2/LICENSE",
  "git_url": "https://api.github.com/repos/SeldonIO/seldon-core/git/blobs/61137502263e30fd4017add89159cd9ffbee8320",
  "download_url": "https://raw.githubusercontent.com/SeldonIO/seldon-core/v2/LICENSE",
  "type": "file",
...
```

**Checklist:**

If PR related to **Optional-Test-Infra**,
- [ ] Changes need to be generated to `aws/GitOps` folder: 
    1. `cd aws`
    2. `make optional-generate`
    3. `make optional-test`
